### PR TITLE
Add double touch option with tests and another five examples

### DIFF
--- a/examples/double_no_touch_option_example.py
+++ b/examples/double_no_touch_option_example.py
@@ -5,13 +5,13 @@ from qdp_python import *
 =====================================================
 option contract details:
  
-option type: Double One Touch
+option type: Double No Touch
 
 start date = 2018/1/3
 maturity date = 2019/1/3
 barrier : 80%
 high_barrier: 120%
-knock out as coupon , 10% annualized by Act365() convention
+if never knock out, pay coupon at maturity, 10% annualized by Act365() convention
 knock out observation : monthly
 
 other variables:
@@ -24,9 +24,9 @@ dividend yield = 1%
 =================================================================
 
 Pricing result comparison details:
-quad pv = 3.74560560260911
-mc pv = 3.741268379019219
-relative error = (quad pv / mc pv - 1) * 100 = 0.12%
+quad pv = 2.11446887494785
+mc pv = 2.1155402208903387
+relative error = (quad pv / mc pv - 1) * 100 = -0.05%
 
 '''
 
@@ -37,9 +37,9 @@ start_date = Date(2018, 1, 3)
 maturity_date = Date(2019, 1, 3)
 spot = 100
 
-barrier_type = BarrierType.DoubleOneTouch
+barrier_type = BarrierType.DoubleNoTouch
 
-# construct knock out coupon
+# construct never knock out coupon
 coupon_rate = InterestRate(0.1)
 
 coupon = Coupon(start_date, spot, coupon_rate)
@@ -50,9 +50,9 @@ observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(
 
 barrier = Barrier(observation_dates, 80, barrier_type, 120)
 
-hit_payoff = CashOrNothingPayoff(PayoffType.Call, 120, coupon) + CashOrNothingPayoff(PayoffType.Put, 80, coupon)
+hit_payoff = CashOrNothingPayoff(PayoffType.Call, 120, 0) + CashOrNothingPayoff(PayoffType.Put, 80, 0)
 
-unhit_payoff = CashOrNothingPayoff(PayoffType.Call, 80, 0)
+unhit_payoff = CashOrNothingPayoff(PayoffType.Call, 80, coupon)
 
 option = BarrierOption(spot,
                        start_date,
@@ -67,7 +67,7 @@ volatility = 0.3
 
 process = BlackScholesProcess(start_date, spot, risk_free_rate, dividend_yield, volatility, day_counter)
 
-engine = MonteCarloEngine(process, 1000000)
+engine = MonteCarloEngine(process, 100000)
 
 npv = option.pv(engine)
 print(npv)

--- a/examples/double_one_touch_option_example.py
+++ b/examples/double_one_touch_option_example.py
@@ -5,12 +5,12 @@ from qdp_python import *
 =====================================================
 option contract details:
  
-option type: Up Out Call
+option type: Double One Touch
 
 start date = 2018/1/3
 maturity date = 2019/1/3
-strike = 100%
-barrier : 120%
+barrier : 80%
+high_barrier: 120%
 knock out as coupon , 10% annualized by Act365() convention
 knock out observation : monthly
 
@@ -24,9 +24,9 @@ dividend yield = 1%
 =================================================================
 
 Pricing result comparison details:
-quad pv = 2.81680297949105
-mc pv = 2.808227826471619 
-relative error = (quad pv / mc pv - 1) * 100 = 0.31%
+quad pv = 3.74560560260911
+mc pv = 3.741268379019219
+relative error = (quad pv / mc pv - 1) * 100 = 0.12%
 
 '''
 
@@ -37,7 +37,7 @@ start_date = Date(2018, 1, 3)
 maturity_date = Date(2019, 1, 3)
 spot = 100
 
-barrier_type = BarrierType.UpOut
+barrier_type = BarrierType.DoubleOneTouch
 
 # construct knock out coupon
 coupon_rate = InterestRate(0.1)
@@ -48,11 +48,11 @@ observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(
                      Date(2018, 6, 4), Date(2018, 7, 3), Date(2018, 8, 3), Date(2018, 9, 3),
                      Date(2018, 10, 8), Date(2018, 11, 5), Date(2018, 12, 3), Date(2019, 1, 3)]
 
-barrier = Barrier(observation_dates, 120, barrier_type)
+barrier = Barrier(observation_dates, 80, barrier_type, 120)
 
-hit_payoff = CashOrNothingPayoff(PayoffType.Call, barrier, coupon)
+hit_payoff = CashOrNothingPayoff(PayoffType.Call, 120, coupon) + CashOrNothingPayoff(PayoffType.Put, 80, coupon)
 
-unhit_payoff = VanillaPayoff(PayoffType.Call, 100)
+unhit_payoff = CashOrNothingPayoff(PayoffType.Put, 120, 0) + CashOrNothingPayoff(PayoffType.Call, 80, 0)
 
 option = BarrierOption(spot,
                        start_date,
@@ -67,7 +67,7 @@ volatility = 0.3
 
 process = BlackScholesProcess(start_date, spot, risk_free_rate, dividend_yield, volatility, day_counter)
 
-engine = MonteCarloEngine(process, 100000)
+engine = MonteCarloEngine(process, 1000000)
 
 npv = option.pv(engine)
 print(npv)

--- a/examples/down_in_option_example.py
+++ b/examples/down_in_option_example.py
@@ -5,14 +5,16 @@ from qdp_python import *
 =====================================================
 option contract details:
  
-option type: Up Out Call
+option type: Down In Put
 
 start date = 2018/1/3
 maturity date = 2019/1/3
 strike = 100%
 barrier : 120%
-knock out as coupon , 10% annualized by Act365() convention
-knock out observation : monthly
+
+knock in as put
+knock in observation : monthly
+never knock in as coupon, 0%
 
 other variables:
 
@@ -24,9 +26,9 @@ dividend yield = 1%
 =================================================================
 
 Pricing result comparison details:
-quad pv = 2.81680297949105
-mc pv = 2.808227826471619 
-relative error = (quad pv / mc pv - 1) * 100 = 0.31%
+quad pv = 9.25564431602257
+mc pv = 9.279286145825028
+relative error = (quad pv / mc pv - 1) * 100 = -0.25%
 
 '''
 
@@ -37,22 +39,21 @@ start_date = Date(2018, 1, 3)
 maturity_date = Date(2019, 1, 3)
 spot = 100
 
-barrier_type = BarrierType.UpOut
+barrier_type = BarrierType.DownIn
 
-# construct knock out coupon
-coupon_rate = InterestRate(0.1)
-
+# construct never knock in coupon
+coupon_rate = InterestRate(0.0)
 coupon = Coupon(start_date, spot, coupon_rate)
 
 observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(2018, 5, 3),
                      Date(2018, 6, 4), Date(2018, 7, 3), Date(2018, 8, 3), Date(2018, 9, 3),
                      Date(2018, 10, 8), Date(2018, 11, 5), Date(2018, 12, 3), Date(2019, 1, 3)]
 
-barrier = Barrier(observation_dates, 120, barrier_type)
+barrier = Barrier(observation_dates, 80, barrier_type)
 
-hit_payoff = CashOrNothingPayoff(PayoffType.Call, barrier, coupon)
+hit_payoff = VanillaPayoff(PayoffType.Put, 100)
 
-unhit_payoff = VanillaPayoff(PayoffType.Call, 100)
+unhit_payoff = CashOrNothingPayoff(PayoffType.Call, barrier, coupon)
 
 option = BarrierOption(spot,
                        start_date,

--- a/examples/down_out_option_example.py
+++ b/examples/down_out_option_example.py
@@ -5,12 +5,12 @@ from qdp_python import *
 =====================================================
 option contract details:
  
-option type: Up Out Call
+option type: Down Out Put
 
 start date = 2018/1/3
 maturity date = 2019/1/3
 strike = 100%
-barrier : 120%
+barrier : 80%
 knock out as coupon , 10% annualized by Act365() convention
 knock out observation : monthly
 
@@ -24,9 +24,9 @@ dividend yield = 1%
 =================================================================
 
 Pricing result comparison details:
-quad pv = 2.81680297949105
-mc pv = 2.808227826471619 
-relative error = (quad pv / mc pv - 1) * 100 = 0.31%
+quad pv = 3.49292314574235
+mc pv = 3.507378730249968
+relative error = (quad pv / mc pv - 1) * 100 = -0.41%
 
 '''
 
@@ -37,7 +37,7 @@ start_date = Date(2018, 1, 3)
 maturity_date = Date(2019, 1, 3)
 spot = 100
 
-barrier_type = BarrierType.UpOut
+barrier_type = BarrierType.DownOut
 
 # construct knock out coupon
 coupon_rate = InterestRate(0.1)
@@ -48,11 +48,11 @@ observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(
                      Date(2018, 6, 4), Date(2018, 7, 3), Date(2018, 8, 3), Date(2018, 9, 3),
                      Date(2018, 10, 8), Date(2018, 11, 5), Date(2018, 12, 3), Date(2019, 1, 3)]
 
-barrier = Barrier(observation_dates, 120, barrier_type)
+barrier = Barrier(observation_dates, 80, barrier_type)
 
-hit_payoff = CashOrNothingPayoff(PayoffType.Call, barrier, coupon)
+hit_payoff = CashOrNothingPayoff(PayoffType.Put, barrier, coupon)
 
-unhit_payoff = VanillaPayoff(PayoffType.Call, 100)
+unhit_payoff = VanillaPayoff(PayoffType.Put, 100)
 
 option = BarrierOption(spot,
                        start_date,

--- a/examples/up_in_option_example.py
+++ b/examples/up_in_option_example.py
@@ -5,14 +5,16 @@ from qdp_python import *
 =====================================================
 option contract details:
  
-option type: Up Out Call
+option type: Up In Call
 
 start date = 2018/1/3
 maturity date = 2019/1/3
 strike = 100%
 barrier : 120%
-knock out as coupon , 10% annualized by Act365() convention
-knock out observation : monthly
+
+knock in as call 
+knock in observation : monthly
+never knock in as coupon, 0%
 
 other variables:
 
@@ -24,9 +26,9 @@ dividend yield = 1%
 =================================================================
 
 Pricing result comparison details:
-quad pv = 2.81680297949105
-mc pv = 2.808227826471619 
-relative error = (quad pv / mc pv - 1) * 100 = 0.31%
+quad pv = 11.771861580065
+mc pv = 11.79891769674576
+relative error = (quad pv / mc pv - 1) * 100 = -0.23%
 
 '''
 
@@ -37,11 +39,10 @@ start_date = Date(2018, 1, 3)
 maturity_date = Date(2019, 1, 3)
 spot = 100
 
-barrier_type = BarrierType.UpOut
+barrier_type = BarrierType.UpIn
 
-# construct knock out coupon
-coupon_rate = InterestRate(0.1)
-
+# construct never knock in coupon
+coupon_rate = InterestRate(0.0)
 coupon = Coupon(start_date, spot, coupon_rate)
 
 observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(2018, 5, 3),
@@ -50,9 +51,9 @@ observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(
 
 barrier = Barrier(observation_dates, 120, barrier_type)
 
-hit_payoff = CashOrNothingPayoff(PayoffType.Call, barrier, coupon)
+hit_payoff = VanillaPayoff(PayoffType.Call, 100)
 
-unhit_payoff = VanillaPayoff(PayoffType.Call, 100)
+unhit_payoff = CashOrNothingPayoff(PayoffType.Put, barrier, coupon)
 
 option = BarrierOption(spot,
                        start_date,

--- a/qdp_python/modules/barrier.py
+++ b/qdp_python/modules/barrier.py
@@ -12,6 +12,8 @@ class BarrierType(enumerate):
     DownOut = 2
     UpIn = 3
     DownIn = 4
+    DoubleOneTouch = 5
+    DoubleNoTouch = 6
 
 
 '''
@@ -42,17 +44,30 @@ def create_dict(keys, values) -> dict:
 
 class Barrier:
 
-    def __init__(self, observation_dates: List[Date], barrier_values, barrier_type: BarrierType):
+    def __init__(self, observation_dates: List[Date], barrier_values, barrier_type: BarrierType,
+                 high_barrier_values=None):
         self._barrier_dict = create_dict(observation_dates, barrier_values)
         self.barrier_type = barrier_type
+        self._high_barrier_dict = create_dict(observation_dates, high_barrier_values)
 
     def is_hit(self, date: Date, spot: float) -> bool:
         barrier = self[date]
+        try:
+            self._high_barrier_dict[date]
+        except KeyError:
+            high_barrier = None
+        else:
+            high_barrier = self._high_barrier_dict[date]
         if barrier is not None:
             barrier_type = self.barrier_type
             if (barrier_type == BarrierType.UpOut or barrier_type == BarrierType.UpIn) and spot > barrier:
                 return True
             if (barrier_type == BarrierType.DownOut or barrier_type == BarrierType.DownIn) and spot < barrier:
+                return True
+        if high_barrier is not None:
+            barrier_type = self.barrier_type
+            if (barrier_type == BarrierType.DoubleOneTouch or barrier_type == BarrierType.DoubleNoTouch) and (
+                    spot > high_barrier or spot < barrier):
                 return True
         return False
 
@@ -65,3 +80,6 @@ class Barrier:
             return self._barrier_dict[date]
         except KeyError:
             return None
+
+
+

--- a/qdp_python/products/barrier_option.py
+++ b/qdp_python/products/barrier_option.py
@@ -8,7 +8,7 @@ class BarrierOption:
                  maturity_date,
                  barrier,
                  hit_payoff,
-                 unhit_payoff):
+                 unhit_payoff,):
         self.spot = initial_spot
         self.start_date = start_date
         self.maturity_date = maturity_date
@@ -19,7 +19,8 @@ class BarrierOption:
         self.observation_dates = sorted({maturity_date}.union(barrier.observation_dates))
 
     def pv_by_path(self, dates, st, df):
-        if (self.barrier.barrier_type == BarrierType.UpOut) or (self.barrier.barrier_type == BarrierType.DownOut):
+        if (self.barrier.barrier_type == BarrierType.UpOut) or (self.barrier.barrier_type == BarrierType.DownOut) or (
+                self.barrier.barrier_type == BarrierType.DoubleOneTouch):
             for t in range(len(dates)):
                 d = dates[t]
                 s = st[t]
@@ -28,7 +29,8 @@ class BarrierOption:
 
             return self.unhit_payoff.pay(st[-1], dates[-1]) * df[-1]
 
-        elif (self.barrier.barrier_type == BarrierType.UpIn) or (self.barrier.barrier_type == BarrierType.DownIn):
+        elif (self.barrier.barrier_type == BarrierType.UpIn) or (self.barrier.barrier_type == BarrierType.DownIn) or (
+                self.barrier.barrier_type == BarrierType.DoubleNoTouch):
             for t in range(len(dates)):
                 d = dates[t]
                 s = st[t]
@@ -42,3 +44,5 @@ class BarrierOption:
 
     def pv(self, engine):
         return engine.calc_pv(self)
+
+

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -16,3 +16,17 @@ class TestBarrier(TestCase):
         self.assertTrue(barrier.is_hit(observation_dates[1], 1.5))
         self.assertTrue(barrier.is_hit(observation_dates[2], 2.1))
         self.assertTrue(barrier.is_hit(observation_dates[3], 2.1))
+
+    def test_is_hit_for_double_barrier(self):
+        observation_dates = [Date(2021, 2, 17), Date(2021, 2, 18),
+                             Date(2021, 3, 18), Date(2021, 4, 18),
+                             Date(2021, 5, 18), Date(2021, 6, 18),
+                             Date(2021, 7, 18), Date(2021, 8, 18)]
+        barrier_values = [1, 2, 3]
+        high_barrier_values = [2, 3, 4]
+        barrier = Barrier(observation_dates, barrier_values, BarrierType.DoubleOneTouch, high_barrier_values)
+
+        self.assertTrue(barrier.is_hit(observation_dates[0], 0.9))
+        self.assertTrue(barrier.is_hit(observation_dates[1], 3.1))
+
+

--- a/tests/test_barrier_option.py
+++ b/tests/test_barrier_option.py
@@ -3,58 +3,99 @@ from unittest import TestCase
 from qdp_python import *
 
 
-class TestBarrier(TestCase):
+class TestBarrierOption(TestCase):
     def test_up_out_pv_by_path(self):
+        """
+        test up out call option pv by path
+
+        params: barrier = 120, coupon = [10, 11, 12, 13], strike = 100
+
+        path1: knock out on the third observation day, pay coupon, pv should be 12
+        path2: never knock out, pay a call, pv should be Max(st[-1]-100, 0) = 8
+
+        """
         spot = 100
         strike = 100
-        coupon = 15
-        hit_payoff = CashOrNothingPayoff(PayoffType.Call, 120, coupon)
-        unhit_payoff = VanillaPayoff(PayoffType.Call, strike)
 
         observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(2018, 5, 3)]
         start_date = observation_dates[0]
         maturity_date = observation_dates[-1]
 
+        coupon = {observation_dates[0]: 10, observation_dates[1]: 11, observation_dates[2]: 12,
+                  observation_dates[3]: 13}
+
+        hit_payoff = CashOrNothingPayoff(PayoffType.Call, 120, coupon)
+        unhit_payoff = VanillaPayoff(PayoffType.Call, strike)
+
         barrier = Barrier(observation_dates, 120, BarrierType.UpOut)
 
-        st1 = [100, 105, 121, 130]
-        df = [1, 1, 1, 1]
         option = BarrierOption(spot,
                                start_date,
                                maturity_date,
                                barrier,
                                hit_payoff,
                                unhit_payoff)
-        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 15)
+        df = [1, 1, 1, 1]
+
+        # path1:  knock out on the third observation day, pay coupon = 12
+        st1 = [100, 113, 121, 130]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 12)
+
+        # path2: never knock out, pay a call = 108 - 100 = 8
         st2 = [100, 80, 90, 108]
         self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st2, df), 8)
 
     def test_down_out_pv_by_path(self):
+        """
+        test down out put option pv by path
+
+        params: barrier = 80, coupon = [10, 11, 12, 13], strike = 100
+
+        path1: knock out on the fourth observation day, pay coupon, pv should be 13
+        path2: never knock out, pay a put, pv should be Max(100 - st[-1], 0) = 2
+
+        """
         spot = 100
         strike = 100
-        coupon = 15
-        hit_payoff = CashOrNothingPayoff(PayoffType.Put, 80, coupon)
-        unhit_payoff = VanillaPayoff(PayoffType.Put, strike)
 
         observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(2018, 5, 3)]
         start_date = observation_dates[0]
         maturity_date = observation_dates[-1]
 
+        coupon = {observation_dates[0]: 10, observation_dates[1]: 11, observation_dates[2]: 12,
+                  observation_dates[3]: 13}
+
+        hit_payoff = CashOrNothingPayoff(PayoffType.Put, 80, coupon)
+        unhit_payoff = VanillaPayoff(PayoffType.Put, strike)
+
         barrier = Barrier(observation_dates, 80, BarrierType.DownOut)
 
-        st1 = [100, 90, 85, 70]
-        df = [1, 1, 1, 1]
         option = BarrierOption(spot,
                                start_date,
                                maturity_date,
                                barrier,
                                hit_payoff,
                                unhit_payoff)
-        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 15)
+        df = [1, 1, 1, 1]
+
+        # path1: knock out on the fourth observation day, pay coupon = 13
+        st1 = [100, 90, 85, 70]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 13)
+
+        # path2: never knock out, pay put = 100 - 98 = 2
         st2 = [100, 85, 90, 98]
         self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st2, df), 2)
 
     def test_up_in_pv_by_path(self):
+        """
+        test up in call option pv by path
+
+        params: barrier = 120, coupon = 15, strike = 100
+
+        path1: knock in, pay a call, pv should be Max(st[-1] - 100, 0) = 30
+        path2: never knock in, pay coupon, pv should be coupon = 15
+
+        """
         spot = 100
         strike = 100
         coupon = 15
@@ -67,19 +108,32 @@ class TestBarrier(TestCase):
 
         barrier = Barrier(observation_dates, 120, BarrierType.UpIn)
 
-        st1 = [100, 105, 121, 130]
-        df = [1, 1, 1, 1]
         option = BarrierOption(spot,
                                start_date,
                                maturity_date,
                                barrier,
                                hit_payoff,
                                unhit_payoff)
+        df = [1, 1, 1, 1]
+
+        # path1: knock in, pay a call, pv = 130 - 100 = 30
+        st1 = [100, 105, 121, 130]
         self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 30)
+
+        # path2: never knock in, pay coupon = 15
         st2 = [100, 80, 90, 108]
         self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st2, df), 15)
 
     def test_down_in_pv_by_path(self):
+        """
+        test down in put option pv by path
+
+        params: barrier = 80, coupon = 15, strike = 100
+
+        path1: knock in, pay a put, pv should be Max(100 - st[-1], 0) = 30
+        path2: never knock in, pay coupon, pv should be coupon = 15
+
+        """
         spot = 100
         strike = 100
         coupon = 15
@@ -92,14 +146,108 @@ class TestBarrier(TestCase):
 
         barrier = Barrier(observation_dates, 80, BarrierType.DownIn)
 
-        st1 = [100, 90, 85, 70]
-        df = [1, 1, 1, 1]
         option = BarrierOption(spot,
                                start_date,
                                maturity_date,
                                barrier,
                                hit_payoff,
                                unhit_payoff)
+        df = [1, 1, 1, 1]
+        # path1: knock in, pay a put, pv = 100 - 70 = 30
+        st1 = [100, 90, 85, 70]
         self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 30)
+        # path2: never knock in, pay coupon = 15
         st2 = [100, 85, 90, 101]
         self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st2, df), 15)
+
+    def test_double_out_pv_by_path(self):
+        """
+        test double out call option pv by path
+
+        params: barrier = 80, high_barrier = 120, coupon = 15, strike = 100
+
+        path1: knock down out on the fourth observation day, pv should be coupon = 13
+        path2: knock up out on the third observation day, pv should be coupon = 12
+        path3: never knock out, pay a call, pv should be Max(st[-1] - 100) = 1
+
+        """
+        spot = 100
+        strike = 100
+
+        observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(2018, 5, 3)]
+        start_date = observation_dates[0]
+        maturity_date = observation_dates[-1]
+
+        coupon = {observation_dates[0]: 10, observation_dates[1]: 11, observation_dates[2]: 12,
+                  observation_dates[3]: 13}
+
+        hit_payoff = CashOrNothingPayoff(PayoffType.Call, 120, coupon) + CashOrNothingPayoff(PayoffType.Put, 80, coupon)
+        unhit_payoff = VanillaPayoff(PayoffType.Call, strike)
+
+        barrier = Barrier(observation_dates, 80, BarrierType.DoubleOneTouch, high_barrier_values=120)
+
+        option = BarrierOption(spot,
+                               start_date,
+                               maturity_date,
+                               barrier,
+                               hit_payoff,
+                               unhit_payoff)
+        df = [1, 1, 1, 1]
+
+        # path1: knock down out on the fourth observation day, coupon = 13
+        st1 = [100, 90, 85, 70]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 13)
+
+        # path2: knock up out on the third observation day, coupon = 12
+        st2 = [100, 110, 121, 119]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st2, df), 12)
+
+        # path2: never knock out, pay a call, pv = 101 - 100 = 1
+        st3 = [100, 85, 90, 101]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st3, df), 1)
+
+    def test_double_In_pv_by_path(self):
+        """
+        test double In Put option pv by path
+
+        params: barrier = 80, high_barrier = 120, coupon = 15, strike = 100
+
+        path1: knock down In on the fourth observation day, pv should be Max(100 - st[-1], 0)
+        path2: knock up In on the third observation day, pv should be Max(100 - st[-1], 0)
+        path3: never knock In, pay a coupon
+
+        """
+        spot = 100
+        strike = 100
+
+        observation_dates = [Date(2018, 2, 5), Date(2018, 3, 5), Date(2018, 4, 3), Date(2018, 5, 3)]
+        start_date = observation_dates[0]
+        maturity_date = observation_dates[-1]
+
+        coupon = 15
+
+        unhit_payoff = CashOrNothingPayoff(PayoffType.Put, 120, coupon) + CashOrNothingPayoff(PayoffType.Call, 80,
+                                                                                              coupon)
+        hit_payoff = VanillaPayoff(PayoffType.Put, strike)
+
+        barrier = Barrier(observation_dates, 80, BarrierType.DoubleNoTouch, high_barrier_values=120)
+
+        option = BarrierOption(spot,
+                               start_date,
+                               maturity_date,
+                               barrier,
+                               hit_payoff,
+                               unhit_payoff)
+        df = [1, 1, 1, 1]
+
+        # path1: knock down In on the fourth observation day, pv = 100 - 70 = 30
+        st1 = [100, 90, 85, 70]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st1, df), 30)
+
+        # path2: knock up In on the third observation day, pv = 100 - 95 = 5
+        st2 = [100, 110, 121, 95]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st2, df), 5)
+
+        # path3: never knock In, pay a coupon = 15
+        st3 = [100, 85, 90, 101]
+        self.assertTrue(BarrierOption.pv_by_path(option, observation_dates, st3, df), 15)


### PR DESCRIPTION
1. Add double one touch and double no touch in barrier_option.py;
2. Add double one touch and double no touch pv_by_path tests;
3. Add down_put_option_example, up_in_option_example, down_in_option_example, double_one_touch_example and double_one_touch_example; 
4. Add some remarks in barrier_option_test.

Others：add two barrier type in barrier.py;  modified day_counter in examples.

